### PR TITLE
(QA-9587) Update calendar-fr.js

### DIFF
--- a/src/main/resources/javascript/i18n/calendar-fr.js
+++ b/src/main/resources/javascript/i18n/calendar-fr.js
@@ -40,5 +40,5 @@ var i18nDefaults = {
     firstDay:0 // Lundi premier jour de la semaine
 };
 
-jQuery.fullCalendar.setDefaults(i18nDefaults);
+//jQuery.fullCalendar.setDefaults(i18nDefaults);
 


### PR DESCRIPTION
Remove wrong/old i18nSettings loading in fullCalendar (setDefaults() function is not accessible from this context).
See calendar / src / main / resources / jnt_calendar / html / calendar.jsp  line 85 for correct initialization (already present).
Rem: in some context this error prevent this last initialization to work.